### PR TITLE
Sanitization Logic: Add NativePtr sanitization

### DIFF
--- a/src/Server/Compiler.fs
+++ b/src/Server/Compiler.fs
@@ -40,5 +40,7 @@ let run libPath (submissionPath: string) (checker: FSharpChecker) =
 let compileSubmission libPath submissionPath =
   let checker = FSharpChecker.Create ()
   if Sanitizer.sanitize submissionPath checker then
-    Error "Sanitization failed. Are you using 'System' module?\n"
+    "Sanitization failed. The following identifiers are banned: "
+    + (Sanitizer.unsafe |> String.concat ", ")
+    + "\n" |> Error
   else run libPath submissionPath checker


### PR DESCRIPTION
The use of `FSharp.NativeInterop.NativePtr` is not blacklisted, allowing an offending client code to DoS the server (tested on a local server). Since this is virtually an arbitrary RW primitive, this may even be used as an exploitation vector.

Sanitizer is fixed to blacklist both `"System"` and `"NativePtr"`, and the error response string inside Compiler is modified accordingly.

PoC is intentionally omitted.