### PR TITLE
(Suggestion) A few missing cases for sanitation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs
+.ionide/
 [Bb]in/
 [Oo]bj/
 db/

--- a/src/Server/Sanitizer.fs
+++ b/src/Server/Sanitizer.fs
@@ -23,7 +23,8 @@ let isTypeInheritUnsafe = function
 let rec visitExpr = function
   // Application
   | SynExpr.App (_, _, f, arg, _) ->
-    visitExpr f || visitExpr arg
+    visitExpr f
+    || visitExpr arg
 
   // Long Identifier
   | SynExpr.LongIdent (_, LongIdentWithDots (ident, _), _, _) ->
@@ -81,7 +82,7 @@ let rec visitExpr = function
   | SynExpr.Set (_, e, _)
   | SynExpr.LongIdentSet (_, e, _) ->
     visitExpr e
-  | SynExpr.NamedIndexedPropertySet (LongIdentWithDots (_, _), i, e, _) ->
+  | SynExpr.NamedIndexedPropertySet (_, i, e, _) ->
     visitExpr i || visitExpr e
   | SynExpr.DotGet (e, _, _, _) ->
     visitExpr e
@@ -158,6 +159,9 @@ let rec sanitizeMembers (defns : SynMemberDefns) =
         bindings |> List.exists visitBinding
       | SynMemberDefn.Interface (_, def, _) ->
         (match def with | Some def -> sanitizeMembers def | None -> false)
+      | SynMemberDefn.ImplicitInherit (pType, args, _, _) ->
+        pType |> isTypeInheritUnsafe
+        || visitExpr args
       | SynMemberDefn.Inherit (pType, _, _) ->
         pType |> isTypeInheritUnsafe
       | SynMemberDefn.AutoProperty (_, _, _, _, _, _, _, _, e, _, _) ->

--- a/src/Server/Sanitizer.fs
+++ b/src/Server/Sanitizer.fs
@@ -13,42 +13,164 @@ let unsafe = ["System"; "NativePtr"]
 let isLongIdentIncludeUnsafe (ident: LongIdent) =
   ident |> Seq.exists (fun i -> List.contains i.idText unsafe)
 
+let isTypeInheritUnsafe = function
+  | SynType.LongIdent (LongIdentWithDots(ident, _)) ->
+    ident |> isLongIdentIncludeUnsafe
+  | SynType.LongIdentApp (_, LongIdentWithDots(ident, _), _, _, _, _, _) ->
+    ident |> isLongIdentIncludeUnsafe
+  | _ -> false
+
 let rec visitExpr = function
+  // Application
   | SynExpr.App (_, _, f, arg, _) ->
     visitExpr f
     || visitExpr arg
+
+  // Long Identifier
   | SynExpr.LongIdent (_, LongIdentWithDots (ident, _), _, _) ->
     ident |> isLongIdentIncludeUnsafe
-  | SynExpr.Match (_, e, clauses, _) ->
+
+  // Match expressions
+  | SynExpr.Match (_, e, clauses, _)
+  | SynExpr.MatchBang (_, e, clauses, _) ->
     visitExpr e
-    || clauses |> List.fold (fun acc (Clause (_, wh, e, _, _)) ->
-      acc
-      || visitExpr e
-      || (match wh with | Some e -> visitExpr e | None -> false)) false
+    || clauses |> List.fold visitClause false
+  | SynExpr.MatchLambda (_, _, clauses, _, _) ->
+    clauses |> List.fold visitClause false // Maybe List.exists?
+
+  // If-Then-Else expression
   | SynExpr.IfThenElse (g, t, f, _, _, _, _) ->
     visitExpr g
     || visitExpr t
     || (match f with | Some f -> visitExpr f | None -> false)
+
+  // Let/Use expression
   | SynExpr.LetOrUse (_, _, bindings, body, _) ->
     bindings
-    |> List.forall (fun (Binding (_, _, _, _, _, _, _, _, _, e, _, _)) ->
+    |> List.forall (fun (Binding (_, _, _, _, _, _, _, _, _, e, _, _)) -> // Why is this forall?
       visitExpr e)
     || visitExpr body
   | SynExpr.LetOrUseBang (_, _, _, _, rhs, _, body, _) ->
     visitExpr rhs || visitExpr body
+
+  // Array/List expression
   | SynExpr.ArrayOrList (_, exprs, _) ->
     exprs |> List.exists visitExpr
   | SynExpr.ArrayOrListOfSeqExpr (_, e, _) ->
     visitExpr e
-  | SynExpr.CompExpr (_, _, e, _) ->
-    visitExpr e
+
+  // Loop expressions
   | SynExpr.ForEach (_, _, _, _, enum, body, _) ->
-    visitExpr enum
-    || visitExpr body
+    visitExpr enum || visitExpr body
+  | SynExpr.For (_, _, f, _, t, d, _) ->
+    visitExpr f || visitExpr t || visitExpr d
+  | SynExpr.While (_, cond, body, _) ->
+    visitExpr cond || visitExpr body
+
+  // Sequential, Tuple expression
   | SynExpr.Sequential (_, _, e1, e2, _) ->
-    visitExpr e1
-    || visitExpr e2
+    visitExpr e1 || visitExpr e2
+  | SynExpr.Tuple (_, exprs, _, _) ->
+    exprs |> List.exists visitExpr
+
+  // Exception expressions
+  | SynExpr.TryFinally(t, f, _, _, _) ->
+    visitExpr t || visitExpr f
+  | SynExpr.TryWith(body, _, cases, _, _, _, _) ->
+    visitExpr body
+    || cases |> List.fold visitClause false
+
+  // Get/Set expressions
+  | SynExpr.Set (id, e, _) ->
+    visitExpr id || visitExpr e
+  | SynExpr.LongIdentSet (LongIdentWithDots (ident, _), e, _) ->
+    ident |> isLongIdentIncludeUnsafe
+    || visitExpr e
+  | SynExpr.NamedIndexedPropertySet (LongIdentWithDots (ident, _), i, e, _) ->
+    ident |> isLongIdentIncludeUnsafe
+    || visitExpr i || visitExpr e
+  | SynExpr.DotGet (e, _, _, _) ->
+    visitExpr e
+  | SynExpr.DotIndexedGet (e, indices, _, _) ->
+    visitExpr e
+    || indices |> List.exists visitIndex
+  | SynExpr.DotSet (p, _, e, _) ->
+    visitExpr p || visitExpr e
+  | SynExpr.DotIndexedSet (p, indices, e, _, _, _) ->
+    visitExpr p || visitExpr e
+    || indices |> List.exists visitIndex
+  | SynExpr.DotNamedIndexedPropertySet (p, _, i, e, _) ->
+    visitExpr p || visitExpr i || visitExpr e
+
+  // Record expressions
+  | SynExpr.Record (con, copy, fields, _) ->
+    (match con with | Some (_, e, _, _, _) -> visitExpr e | None -> false)
+    || (match copy with | Some (e, _) -> visitExpr e | None -> false)
+    || fields |> List.exists (function | (_, Some e, _) -> visitExpr e | _ -> false)
+  | SynExpr.AnonRecd (_, copy, fields, _) ->
+    (match copy with | Some (e, _) -> visitExpr e | None -> false)
+    || fields |> List.exists (fun (_, e) -> visitExpr e)
+
+  // Object expression
+  | SynExpr.ObjExpr (pType, opt, bindings, impls, _, _) ->
+    pType |> isTypeInheritUnsafe
+    || (match opt with | Some (e, _) -> visitExpr e | None -> false)
+    || bindings |> List.forall visitBinding
+    || impls |> List.exists (fun (InterfaceImpl(_, bindings, _)) ->
+      bindings |> List.forall visitBinding)
+
+  // Wrapped cases
+  | SynExpr.Paren (e, _, _, _)
+  | SynExpr.CompExpr (_, _, e, _)
+  | SynExpr.Assert (e, _)
+  | SynExpr.AddressOf (_, e, _, _)
+  | SynExpr.Do (e, _)
+  | SynExpr.DoBang (e, _)
+  | SynExpr.Downcast (e, _, _)
+  | SynExpr.Upcast (e, _, _)
+  | SynExpr.InferredDowncast (e, _)
+  | SynExpr.InferredUpcast (e, _)
+  | SynExpr.Fixed (e, _)
+  | SynExpr.Lazy (e, _)
+  | SynExpr.New (_, _, e, _)
+  | SynExpr.Typed (e, _, _)
+  | SynExpr.TypeTest (e, _, _)
+  | SynExpr.YieldOrReturn (_, e, _)
+  | SynExpr.YieldOrReturnFrom (_, e, _) -> visitExpr e
   | _ -> false
+
+and visitBinding = fun (Binding (_, _, _, _, _, _, _, _, _, e, _, _)) ->
+  visitExpr e
+
+and visitClause = fun acc (Clause (_, wh, e, _, _)) ->
+  acc
+  || visitExpr e
+  || (match wh with | Some e -> visitExpr e | None -> false)
+
+and visitIndex = function
+  | SynIndexerArg.One (index, _, _) ->
+    visitExpr index
+  | SynIndexerArg.Two (index1, _, index2, _, _, _) ->
+    visitExpr index1 || visitExpr index2
+
+let rec sanitizeMembers (defns : SynMemberDefns) =
+  defns
+  |> List.exists (fun defn ->
+    match defn with
+      | SynMemberDefn.Open (ident, _) ->
+        ident |> isLongIdentIncludeUnsafe
+      | SynMemberDefn.Member (binding, _) ->
+        visitBinding binding
+      | SynMemberDefn.LetBindings (bindings, _, _, _) ->
+        bindings |> List.forall visitBinding
+      | SynMemberDefn.Interface (_, def, _) ->
+        (match def with | Some def -> sanitizeMembers def | None -> false)
+      | SynMemberDefn.Inherit (pType, _, _) ->
+        pType |> isTypeInheritUnsafe
+      | SynMemberDefn.AutoProperty (_, _, _, _, _, _, _, _, e, _, _) ->
+        visitExpr e
+      | _ -> false
+  )
 
 let rec sanitizeDecls (decls: SynModuleDecls) =
   decls
@@ -56,16 +178,21 @@ let rec sanitizeDecls (decls: SynModuleDecls) =
     match decl with
     | SynModuleDecl.DoExpr (_, e, _) -> visitExpr e
     | SynModuleDecl.Let (_, bindings, _) ->
-      bindings
-      |> List.forall (fun (Binding (_, _, _, _, _, _, _, _, _, e, _, _)) ->
-        visitExpr e)
+      bindings |> List.forall visitBinding
     | SynModuleDecl.ModuleAbbrev (_, ident, _) ->
       ident |> isLongIdentIncludeUnsafe
     | SynModuleDecl.NestedModule (_, _, decls, _, _) ->
       sanitizeDecls decls
     | SynModuleDecl.Open (LongIdentWithDots (ident, _), _) ->
       ident |> isLongIdentIncludeUnsafe
-    | _ -> false)
+    | SynModuleDecl.Types (types, _) ->
+      types |> List.exists (fun (TypeDefn(_, _, members, _)) ->
+        sanitizeMembers members)
+    | SynModuleDecl.NamespaceFragment (SynModuleOrNamespace (ident, _, _, decls, _, _, _, _)) ->
+      ident |> isLongIdentIncludeUnsafe || sanitizeDecls decls
+    | SynModuleDecl.Exception (_)
+    | SynModuleDecl.Attributes (_)
+    | SynModuleDecl.HashDirective (_) -> false)
 
 let sanitizeModule = function
   | SynModuleOrNamespace (_, _, _, decls, _, _, _, _) -> sanitizeDecls decls


### PR DESCRIPTION
Tried to look through the possible cases of the AST.
Filled in the cases I think could have been problematic, including
 - Missing expression cases
 - Inheritance of System class
 - Namespace fragments

But these changes might not be preferable, and I have a few questions on the choice of List.fold / List.forall / List.exists.
Would you review this?