### PR TITLE
Check code's namespace == tester's namespace

### DIFF
--- a/src/Server/DB.fs
+++ b/src/Server/DB.fs
@@ -74,7 +74,7 @@ let init stime libfile testfile =
     TestDll = testDll
     Students = initStudents ()
     Submissions = Dictionary ()
-    ActivityName = testDll.GetTypes().[0].Namespace}
+    ActivityName = testDll.GetTypes().[0].Namespace }
 
 let assertDBExistence dbpath =
   if File.Exists dbpath then ()

--- a/src/Server/DB.fs
+++ b/src/Server/DB.fs
@@ -32,6 +32,7 @@ type Context = {
   TestDll: Assembly
   Students: Map<string, Student>
   Submissions: Dictionary<string, Submission>
+  ActivityName: string
 }
 
 let [<Literal>] private dbdir = "db"
@@ -66,12 +67,14 @@ let private initStudents () =
 let init stime libfile testfile =
   initDBDir ()
   let libpath, testpath = Compiler.compileTest libfile testfile
+  let testDll = Assembly.LoadFile testpath
   { Token = Random.str 10
     SessionDir = initSessionDir stime
     LibDllPath = libpath
-    TestDll = Assembly.LoadFile testpath
+    TestDll = testDll
     Students = initStudents ()
-    Submissions = Dictionary () }
+    Submissions = Dictionary ()
+    ActivityName = testDll.GetTypes().[0].Namespace}
 
 let assertDBExistence dbpath =
   if File.Exists dbpath then ()
@@ -98,12 +101,14 @@ let deserializeSubmissions sessionDir =
 let reload libfile testfile sessionDir =
   Path.Combine (sessionDir, submissiondb) |> assertDBExistence
   let libpath, testpath = Compiler.compileTest libfile testfile
+  let testDll = Assembly.LoadFile testpath;
   { Token = Random.str 10
     SessionDir = sessionDir
     LibDllPath = libpath
-    TestDll = Assembly.LoadFile testpath
+    TestDll = testDll
     Students = deserializeStudents sessionDir
-    Submissions = deserializeSubmissions sessionDir }
+    Submissions = deserializeSubmissions sessionDir
+    ActivityName = testDll.GetTypes().[0].Namespace }
 
 let getToken ctxt = ctxt.Token
 

--- a/src/Server/Server.fs
+++ b/src/Server/Server.fs
@@ -31,9 +31,12 @@ let processSubmission ctxt student tmppath =
     match asm.GetTypes () |> Array.tryFind (fun t -> t.Name = moduleName) with
     | None -> FORBIDDEN "Module not found (typo in your module?).\n"
     | Some t ->
-      match t.GetMethods () |> Array.tryFind (fun m -> m.Name = "myfunc") with
-      | None -> FORBIDDEN "Function not found (typo in your function?).\n"
-      | Some m -> OK (Checker.check ctxt student m)
+      if t.Namespace <> ctxt.ActivityName then
+        FORBIDDEN "Invalid module namespace (typo in your module?).\n"
+      else
+        match t.GetMethods () |> Array.tryFind (fun m -> m.Name = "myfunc") with
+        | None -> FORBIDDEN "Function not found (typo in your function?).\n"
+        | Some m -> OK (Checker.check ctxt student m)
 
 let handleSubmission ctxt sid lastname token tmppath =
   match DB.findStudent ctxt sid with


### PR DESCRIPTION
The Checker does not validate the client code's namespace, possibly allowing an offending client to send code as below:
```f#
module System.M12345678

let myfunc (x: int) =
  Console.WriteLine "aaa"
  x
```

Since our module is now inside System namespace, we can use functions in System that should've been filtered out.

Fix is applied by extracting namespace from test DLL at DB init, then comparing it with the client module's namespace.