### PR TITLE
Fixed unicode-named directory not found on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs
+.ionide/
 [Bb]in/
 [Oo]bj/
 db/

--- a/src/Server/Server.fs
+++ b/src/Server/Server.fs
@@ -16,7 +16,7 @@ let [<Literal>] myport = 8080
 
 let index =
   let dir =
-    (Uri (Reflection.Assembly.GetExecutingAssembly().CodeBase)).AbsolutePath
+    Path.GetFullPath (Reflection.Assembly.GetExecutingAssembly().Location)
     |> Path.GetDirectoryName
   Path.Combine (dir, "index.html")
   |> File.ReadAllText


### PR DESCRIPTION
Current implementation of URI of .NET Core has problems with other filesystems, which uses other encodings. I think this is a usable alternative.
(Also, noticed that it refers to mscorlib.dll on linux, when it isn't available. Is this related with wrong setup? Sorry for questions)